### PR TITLE
modify FindValidRegion to handle edge case

### DIFF
--- a/src/pile.cpp
+++ b/src/pile.cpp
@@ -120,20 +120,16 @@ void Pile::AddKmers(
 void Pile::FindValidRegion(std::uint16_t coverage) {
   std::uint32_t begin = 0;
   std::uint32_t end = 0;
+  std::uint32_t counter = 0;
   for (std::uint32_t i = begin_; i < end_; ++i) {
-    if (data_[i] < coverage) {
-      continue;
-    }
-    for (std::uint32_t j = i + 1; j < end_; ++j) {
-      if (data_[j] >= coverage) {
-        continue;
+    if (data_[i] >= coverage) {
+      counter++;
+      if (counter > end - begin) {
+        end = i + 1;
+        begin = i - counter + 1;
       }
-      if (end - begin < j - i) {
-        begin = i;
-        end = j;
-      }
-      i = j;
-      break;
+    } else {
+      counter = 0;
     }
   }
   UpdateValidRegion(begin, end);


### PR DESCRIPTION
Hi,

I noticed the function FindValidRegions seems to not pick up the longest valid region if the region continues up to the final position in data_. For example, if data_ = [0, 5, 6, 5, 3, 5, 6, 6, 5] and coverage = 4, the current function would set begin=1 and end=4 whereas this proposed change would set begin=5 and end=9. 

I ran the same E. coli data on a baseline build and a build using the modification here, and didn't observe any changes in the final assembly, but perhaps there are datasets where this edge case would apply. 

Let me know what you think.