### PR TITLE
segmentation fault (core dumped)

### DIFF
--- a/RavenLib/src/construct.cc
+++ b/RavenLib/src/construct.cc
@@ -262,9 +262,13 @@ void ResolveChimericSequences(
       medians.emplace_back(it->median());
     }
   }
-  std::nth_element(medians.begin(), medians.begin() + medians.size() / 2,
+ 
+  std::uint16_t median = 0;
+  if (medians.size() > 0){
+    std::nth_element(medians.begin(), medians.begin() + medians.size() / 2,
                    medians.end());
-  std::uint16_t median = medians[medians.size() / 2];
+    median = medians[medians.size() / 2];
+  }
 
   std::vector<std::future<void>> thread_futures;
   for (const auto& it : piles) {


### PR DESCRIPTION
If you have all regions smaller than 78 (1260 >> kPSS), with coverage grather or equal ot 4, you don't have any valid "pile". When you try to calculate the median, a segmentation fault is raised. This solution avoids this, but I think it is better to inform the user about the lack of overlap because none contigs will be generated.